### PR TITLE
fixed wrong url for UX meetup calendar

### DIFF
--- a/data/groups.json
+++ b/data/groups.json
@@ -133,7 +133,7 @@
 		"name": "Louisville UX Meetup",
 		"frequency": "Meets the 1st Thursday every month @ 5pm",
 		"web": "http://www.meetup.com/Louisville-UX/",
-		"calendar": "http://www.meetup.com/Treehouse-web-development-training-for-beginners/events/ical/"
+		"calendar": "http://www.meetup.com/Louisville-UX/events/ical/"
 	},
 
 	"derbypy": {


### PR DESCRIPTION
UX meetup ical url was wrong.  Fixed