### PR TITLE
Included bourbon and bourbon-neat to fix main.scss paths closes #47

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
   },
   "dependencies": {
     "async": "^1.2.1",
+    "bourbon": "^4.2.7",
+    "bourbon-neat": "^1.7.4",
     "ical": "ericlathrop/ical.js#fix-rrule-dtstart",
+    "node-bourbon": "^4.2.3",
+    "node-neat": "^1.7.2",
     "normalize.scss": "^0.1.0",
     "ramda": "^0.15.1",
-    "unfold": "^0.3.2",
-    "node-bourbon": "^4.2.3",
-    "node-neat": "^1.7.2"
+    "unfold": "^0.3.2"
   },
   "devDependencies": {
     "eslint": "^0.24.0"

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -12,9 +12,9 @@
 // Bourbon, Bitters, Neat, Batch
 //----------------------------------*/
 
-@import "./node_modules/node-bourbon/node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "./node_modules/bourbon/app/assets/stylesheets/bourbon";
 @import "base/base";
-@import "./node_modules/node-neat/node_modules/bourbon-neat/app/assets/stylesheets/neat";
+@import "./node_modules/bourbon-neat/app/assets/stylesheets/neat";
 @import "components/batch";
 
 //----------------------------------*\


### PR DESCRIPTION
Including bourbon and bourbon-neat as dependencies allows the npm install to create the paths needed in main.scss